### PR TITLE
Eager loading of logos instead of lazy loading

### DIFF
--- a/APITaxi/models/security.py
+++ b/APITaxi/models/security.py
@@ -53,7 +53,7 @@ class User(db.Model, UserMixin, MarshalMixin):
     email_technical = Column(db.String, nullable=True,
             label=u'Email du contact technique',
             description=u'Email du contact technique')
-    logos = db.relationship('Logo', backref="user")
+    logos = db.relationship('Logo', backref="user", lazy='joined')
 
     def __init__(self, *args, **kwargs):
         kwargs['apikey'] = str(uuid.uuid4())


### PR DESCRIPTION
Eager loading of operators logos instead of lazy loading (in order to avoid DetachedInstanceErrors on the My Account form)