### PR TITLE
Fix the content negotiation for MSIE

### DIFF
--- a/APITaxi/utils/request_wants_json.py
+++ b/APITaxi/utils/request_wants_json.py
@@ -8,7 +8,7 @@ def request_wants_json():
     best = request.accept_mimetypes \
         .best_match(['application/json', 'text/html'])
     return best == 'application/json' and \
-        request.accept_mimetypes[best] >= \
+        request.accept_mimetypes[best] > \
         request.accept_mimetypes['text/html']
 
 


### PR DESCRIPTION
I am not sure why this was changed on 2015-07-16.

The test case (submitted by YR) was: 'application/json, text/plain, */*'
It does NOT need the ">=" to be interpreted as  'application/json'

OTOH, MSIE sends 'text/html, application/xhtml+xml, */*' which needs ">" to be correctly understood as 'text/html'
