### PR TITLE
Add bcrypt in the requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ Flask-Script==2.0.5
 Flask-Migrate==1.8.1
 Shapely==1.5.13
 pyshp==1.2.3
+bcrypt


### PR DESCRIPTION
L'install de l'API ne fonctionne pas car il manque le module python bcrypt (fait planter la création du compte admin par la ligne de commande). Fait aussi planter fab_taxi.