### PR TITLE
Set DEBUG=False for unittests

### DIFF
--- a/APITaxi/test_settings.py
+++ b/APITaxi/test_settings.py
@@ -1,4 +1,4 @@
-DEBUG = True
+DEBUG = False
 SECRET_KEY = 'super-secret'
 SQLALCHEMY_DATABASE_URI = 'postgresql://apitaxi:vincent@localhost/odtaxi_test'
 REDIS_URL = "redis://:@localhost:6379/0"


### PR DESCRIPTION
Unittests need to be close as possible as the production, and some
components (eg. flask-restplus exception handling) act differently when
debug is set or not.