### PR TITLE
Do not make redis connection on startup

### DIFF
--- a/APITaxi/__init__.py
+++ b/APITaxi/__init__.py
@@ -32,9 +32,7 @@ def create_app(sqlalchemy_uri=None):
     from APITaxi_models import db, security, HailLog
     db.init_app(app)
     redis_store.init_app(app)
-    redis_store.connection_pool.get_connection(0).can_read()
     redis_store_saved.init_app(app)
-    redis_store_saved.connection_pool.get_connection(0).can_read()
     from . import api
     api.init_app(app)
 


### PR DESCRIPTION
On startup, the API no longer attempts to read from redis and endpoints will return HTTP/500 errors until redis is up.