### PR TITLE
Rewrite import_zupc

### DIFF
--- a/APITaxi/commands/__init__.py
+++ b/APITaxi/commands/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+
+import logging
+import sys
+
 from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 from flask_script.commands import ShowUrls
@@ -6,6 +10,9 @@ from flask_script.commands import ShowUrls
 manager = Manager()
 
 def register_commands(manager):
+    # Setup logging for commands that are using it.
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='[%(levelname)s] %(message)s')
+
     from .create_user import (create_operateur, create_moteur, create_admin,
               create_mairie, create_aeroport)
     from .create_influx_db import create_influx_db


### PR DESCRIPTION
Code is more pythonic, more readable and commented. Errors are no longer
silently ignored. No more code duplication. Database can no longer be
corrupted, as we commit the transaction in ZUPC table only once.