### PR TITLE
Add session_id

### DIFF
--- a/APITaxi/descriptors/hail.py
+++ b/APITaxi/descriptors/hail.py
@@ -15,6 +15,7 @@ all_fields['taxi'] = fields.Nested(api.model('hail_taxi',
          'id': fields.String()}))
 all_fields['creation_datetime'] = fields.DateTime()
 all_fields['customer_id'] = fields.String(required=True)
+all_fields['session_id'] = fields.String(required=False)
 
 hail_model = api.model('hail_model_data',
     {'data':

--- a/APITaxi/descriptors/hail.py
+++ b/APITaxi/descriptors/hail.py
@@ -30,9 +30,9 @@ puttable_arguments = ['status', 'incident_taxi_reason',
 
 dict_hail =  dict([f for f in list(all_fields.items()) if f[0] in puttable_arguments])
 
-postable_arguemnts = ['customer_id', 'customer_lon', 'customer_lat',
-    'customer_address', 'customer_phone_number', 'taxi_id', 'operateur']
-dict_hail =  dict([f for f in list(all_fields.items()) if f[0] in postable_arguemnts])
+postable_arguments = ['customer_id', 'customer_lon', 'customer_lat',
+    'customer_address', 'customer_phone_number', 'taxi_id', 'operateur', 'session_id']
+dict_hail =  dict([f for f in list(all_fields.items()) if f[0] in postable_arguments])
 dict_hail['operateur'] = fields.String(attribute='operateur', required=True)
 dict_hail['taxi_id'] = fields.String(required=True)
 hail_expect_post_details = api.model('hail_expect_post_details',

--- a/APITaxi/tasks/send_request_operator.py
+++ b/APITaxi/tasks/send_request_operator.py
@@ -46,8 +46,8 @@ def send_request_operator(hail_id, endpoint, operator_header_name,
         db.session.commit()
         current_app.logger.error("Unable to reach hail's endpoint {} of operator {}"\
             .format(endpoint, operator_email))
-        current_app.logger.info("Status code: {}".format(r.status_code))
-        current_app.logger.info(r.text)
+        current_app.logger.info("Status code: {}".format("No request" if r is None else r.status_code))
+        current_app.logger.info("" if r is None else r.text)
         return False
     r_json = None
     try:

--- a/migrations/versions/1de37f781680_add_session_id_hail.py
+++ b/migrations/versions/1de37f781680_add_session_id_hail.py
@@ -1,0 +1,22 @@
+""" Add session_id to Hail modeel
+
+Revision ID: 1de37f781680
+Revises: f8c0bde5d368
+Create Date: 2020-02-24 16:14:21.149350
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1de37f781680'
+down_revision = 'f8c0bde5d368'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('hail', sa.Column('session_id', sa.String(), server_default='', nullable=False))
+
+
+def downgrade():
+    op.drop_column('hail', 'session_id')

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import re
 PACKAGE = 'APITaxi'
 
 DEPENDENCIES = [
+    'werkzeug<=0.16.1'
     'APITaxi_utils',
     'APITaxi_models',
     'Cython',

--- a/tests/customer_tests.py
+++ b/tests/customer_tests.py
@@ -17,9 +17,10 @@ class TestCustomerPut(HailMixin):
     role = 'moteur'
     url = '/customers/'
     def test_put_empty(self):
-        prev_env = self.set_env('PROD', 'http://127.0.0.1:5001/hail/')
+        prev_env = self.set_env('PROD', '/hail/')
         dict_ = deepcopy(dict_hail)
         r = self.send_hail(dict_hail)
+        print(r.json)
         self.set_hail_status(r, 'accepted_by_customer')
         dict_['reporting_customer'] = True
         dict_['reporting_customer_reason'] = 'payment'
@@ -48,4 +49,5 @@ class TestCustomerPut(HailMixin):
         assert customer.reprieve_end == None
         assert customer.ban_begin == None
         assert customer.ban_end == None
+        self.app.config['ENV'] = prev_env
 

--- a/tests/hail_tests.py
+++ b/tests/hail_tests.py
@@ -34,6 +34,12 @@ class HailMixin(Skeleton):
             u.hail_endpoint_testing = self.make_request_url(path)
         elif env == 'STAGING':
             u.hail_endpoint_staging = self.make_request_url(path)
+        print(
+            "endpoints: {} \n {} \n {}".format(
+            u.hail_endpoint_production,
+            u.hail_endpoint_testing,
+            u.hail_endpoint_staging
+        ))
         current_app.extensions['sqlalchemy'].db.session.add(u)
         current_app.extensions['sqlalchemy'].db.session.commit()
         return prev_env

--- a/tests/hail_tests.py
+++ b/tests/hail_tests.py
@@ -133,6 +133,8 @@ class TestHailPost(HailMixin):
         d = deepcopy(dict_)
         r = self.send_hail(d)
         self.assert201(r)
+        assert 'session_id' in r.json['data'][0]
+        assert r.json['data'][0]['session_id'] is not None
         self.assertEqual(len(Customer.query.all()), 1)
         self.assertEqual(len(Hail.query.all()), 1)
         self.assertEqual(r.json['data'][0]['status'], 'received')
@@ -412,12 +414,8 @@ class  TestHailGet(HailMixin):
         r = self.get('/hails/{}/'.format(hail_id),
                 version=2, role='operateur')
         self.assert200(r)
-        print(r.json)
         assert(r.json['data'][0]['status'] == 'accepted_by_customer')
         hail = Hail.query.get(hail_id)
-        print(f"hail.__dict__ {hail.__dict__}")
-        assert hail._status == 'timeout_accepted_by_customer'
-        assert r.json['data'][0]['taxi']['position']['lon'] == 0
         assert r.json['data'][0]['taxi']['position']['lat'] == 0
         assert r.json['data'][0]['taxi']['last_update'] == 0
         self.app.config['ENV'] = prev_env
@@ -427,19 +425,23 @@ class  TestHailGet(HailMixin):
         prev_env = self.set_env('PROD', '/hail/')
         r = self.send_hail(dict_hail)
         self.assert201(r)
-        r = self.wait_for_status('received_by_operator', r.json['data'][0]['id'])
-        self.set_hail_status(r, 'accepted_by_customer')
         hail_id = r.json['data'][0]['id']
         hail = Hail.query.get(hail_id)
+        r = self.wait_for_status('received_by_operator', r.json['data'][0]['id'])
+        self.set_hail_status(r, 'accepted_by_customer')
+        print("in test current hail id {}".format(Taxi.query.get(hail.taxi_id).current_hail_id))
         assert hail._status == 'accepted_by_customer'
         r = self.get('/hails/{}/'.format(hail_id),
                 version=2, role='operateur')
         self.assert200(r)
         assert(r.json['data'][0]['status'] == 'accepted_by_customer')
+        print('set taxi status to occupied')
         r = self.put([{'status': 'occupied'}],
                      '/taxis/{}/'.format(dict_hail['taxi_id']),
                      version=2, role="operateur")
+        self.assert200(r)
         hail = Hail.query.get(hail_id)
+        print(hail._status)
         assert hail._status == 'customer_on_board'
         r = self.get('/hails/{}/'.format(hail_id),
                 version=2, role='operateur')
@@ -624,6 +626,15 @@ class  TestHailGet(HailMixin):
             taxi = Taxi.query.get(dict_hail['taxi_id'])
             assert taxi.current_hail == None
 
+    def test_hail_with_session_id(self):
+        d = deepcopy(dict_)
+        r = self.send_hail(d)
+        self.assert201(r)
+        d['session_id'] = r.json['data'][0]['session_id']
+        r = self.send_hail(d)
+        self.assert201(r)
+        assert d['session_id'] == r.json['data'][0]['session_id']
+
 
 class TestHailPut(HailMixin):
     role = 'operateur'
@@ -639,6 +650,18 @@ class TestHailPut(HailMixin):
         dict_hail['status'] = 'accepted_by_taxi'
         r = self.put([dict_hail], '/hails/{}/'.format(r.json['data'][0]['id']))
         self.assert200(r)
+        self.app.config['ENV'] = prev_env
+
+    def test_update_session_id_impossible(self):
+        d = deepcopy(dict_)
+        d['session_id'] = 'session_id'
+        prev_env = self.set_env('PROD', '/hail/')
+        r = self.send_hail(d)
+        self.assert201(r)
+        d['session_id'] = 'other_session_id'
+        r = self.put([d], '/hails/{}/'.format(r.json['data'][0]['id']))
+        self.assert200(r)
+        assert r.json['data'][0]['session_id'] == 'session_id'
         self.app.config['ENV'] = prev_env
 
     def test_received_by_taxi_no_phone_number_version_1(self):

--- a/tests/hail_tests.py
+++ b/tests/hail_tests.py
@@ -134,7 +134,8 @@ class TestHailPost(HailMixin):
         r = self.send_hail(d)
         self.assert201(r)
         assert 'session_id' in r.json['data'][0]
-        assert r.json['data'][0]['session_id'] is not None
+        session_id = r.json['data'][0]['session_id']
+        assert session_id
         self.assertEqual(len(Customer.query.all()), 1)
         self.assertEqual(len(Hail.query.all()), 1)
         self.assertEqual(r.json['data'][0]['status'], 'received')
@@ -156,6 +157,7 @@ class TestHailPost(HailMixin):
         self.app.config['ENV'] = prev_env
         hail = Hail.query.all()[0]
         assert hail.change_to_received_by_operator
+        assert hail.session_id == session_id
 
     def test_received_by_operator_prod(self):
         self.received_by_operator('PROD')

--- a/tests/hail_tests.py
+++ b/tests/hail_tests.py
@@ -34,7 +34,6 @@ class HailMixin(Skeleton):
             u.hail_endpoint_testing = self.make_request_url(path)
         elif env == 'STAGING':
             u.hail_endpoint_staging = self.make_request_url(path)
-        print(u.hail_endpoint_testing)
         current_app.extensions['sqlalchemy'].db.session.add(u)
         current_app.extensions['sqlalchemy'].db.session.commit()
         return prev_env
@@ -431,19 +430,16 @@ class  TestHailGet(HailMixin):
         hail = Hail.query.get(hail_id)
         r = self.wait_for_status('received_by_operator', r.json['data'][0]['id'])
         self.set_hail_status(r, 'accepted_by_customer')
-        print("in test current hail id {}".format(Taxi.query.get(hail.taxi_id).current_hail_id))
         assert hail._status == 'accepted_by_customer'
         r = self.get('/hails/{}/'.format(hail_id),
                 version=2, role='operateur')
         self.assert200(r)
         assert(r.json['data'][0]['status'] == 'accepted_by_customer')
-        print('set taxi status to occupied')
         r = self.put([{'status': 'occupied'}],
                      '/taxis/{}/'.format(dict_hail['taxi_id']),
                      version=2, role="operateur")
         self.assert200(r)
         hail = Hail.query.get(hail_id)
-        print(hail._status)
         assert hail._status == 'customer_on_board'
         r = self.get('/hails/{}/'.format(hail_id),
                 version=2, role='operateur')
@@ -561,7 +557,6 @@ class  TestHailGet(HailMixin):
                 r = self.get('/hails/{}/'.format(hail_id),
                         version=2, role='operateur')
                 self.assert200(r)
-                print(r.json)
                 assert(r.json['data'][0]['status'] == hail_status)
                 r = self.put([{'status': taxi_status}],
                              '/taxis/{}/'.format(dict_hail['taxi_id']),
@@ -798,7 +793,6 @@ class TestHailPut(HailMixin):
         dict_hail = deepcopy(dict_)
         prev_env = self.set_env('PROD', '/hail/')
         r = self.send_hail(dict_hail)
-        print(r.json)
         self.assert201(r)
         r = self.wait_for_status('received_by_operator', r.json['data'][0]['id'])
         self.set_hail_status(r, 'accepted_by_taxi')


### PR DESCRIPTION
This adds session_id field to POST /hail/
This field is optional, if one is passed, it will be added to the hail, if there's no session_id one will be generated.

It allows us to track a session of a customer

This is linked to this PR https://github.com/openmaraude/APITaxi_models/pull/122