### PR TITLE
Do not query redis in TaxiSchema

### DIFF
--- a/APITaxi2/redis_backend.py
+++ b/APITaxi2/redis_backend.py
@@ -133,7 +133,7 @@ def log_taxi_status(taxi_id, status):
 
 
 @dataclass
-class _Location:
+class Location:
     lon: float
     lat: float
     distance: float
@@ -148,8 +148,8 @@ def taxis_locations_by_operator(lon, lat, distance):
 
     >>> {
     ...    <taxi_id>: {
-    ...       <operator_email>: _Location object,
-    ...       <operator_email>: _Location object,
+    ...       <operator_email>: Location object,
+    ...       <operator_email>: Location object,
     ...       ...
     ...    }
     ... }
@@ -176,7 +176,7 @@ def taxis_locations_by_operator(lon, lat, distance):
         if update_date:
             update_date = datetime.fromtimestamp(update_date)
 
-        locations[taxi_id][operator] = _Location(
+        locations[taxi_id][operator] = Location(
             lon=location[0],
             lat=location[1],
             distance=distance,

--- a/APITaxi2/tests/test_taxis.py
+++ b/APITaxi2/tests/test_taxis.py
@@ -430,7 +430,12 @@ class TestTaxiList:
         assert len(resp.json['data']) == 2
         # First is closer
         assert resp.json['data'][0]['crowfly_distance'] < resp.json['data'][1]['crowfly_distance']
+        assert resp.json['data'][0]['position']['lon']
+        assert resp.json['data'][0]['position']['lat']
+
         assert resp.json['data'][1]['operator'] == taxi_2_vehicle_descriptions_1.added_by.email
+        assert resp.json['data'][1]['position']['lon']
+        assert resp.json['data'][1]['position']['lat']
 
         # If favorite_operator is set, do not return the default.
         resp = moteur.client.get('/taxis?lon=%s&lat=%s&favorite_operator=%s' % (
@@ -515,6 +520,8 @@ class TestTaxiList:
         assert resp.status_code == 200
         assert len(resp.json['data']) == 1
         assert resp.json['data'][0]['operator'] == vehicle_description.added_by.email
+        assert resp.json['data'][0]['position']['lon']
+        assert resp.json['data'][0]['position']['lat']
 
     def test_different_zupc(self, app, moteur, operateur):
         """Request is made from Paris, and taxi reports it's location in Paris


### PR DESCRIPTION
TaxiSchema.dump expects three arguments: a Taxi, a VehicleDescription
and optionally a Location which can be None or omitted.

Location is used to dump the crowfly_distance in GET
/taxis?lon=xx&lat=xx, but an extra useless query is made to redis to
retrieve taxi's longitude and latitude.

This extra useless query adds a bug:

- if taxi has two operators, let's say operator1 and operator2,
  reporting location1 (fresh) and location2 (old, outdated)
- and if taxi.added_by is operator2

Then GET /taxis?lon/lat=<location1> used to return location2.