### PR TITLE
Replace errors logging with warnings

### DIFF
--- a/APITaxi2/commands/users.py
+++ b/APITaxi2/commands/users.py
@@ -26,7 +26,7 @@ def valid_role(value):
 def create_user(email, password, roles):
     user = User.query.filter_by(email=email).one_or_none()
     if user:
-        current_app.logger.error('User already exists')
+        current_app.logger.warning('User already exists, abort.')
         return
 
     hashed_password = hash_password(password)
@@ -60,7 +60,7 @@ def create_user(email, password, roles):
 def update_password(email, password):
     user = User.query.filter_by(email=email).one_or_none()
     if not user:
-        current_app.logger.error('User does not exist')
+        current_app.logger.warning('User does not exist, abort.')
         return
 
     user.password = hash_password(password)

--- a/APITaxi2/commands/zupc.py
+++ b/APITaxi2/commands/zupc.py
@@ -166,7 +166,7 @@ def fill_zupc_union(filename):
         parent = ZUPC_tmp.query.filter_by(insee=insee_codes[0]).one()
     # Can happen in the case the referenced INSEE code has been previously "renamed" in "special_name_insee".
     except NoResultFound:
-        current_app.logger.error('File %s references ZUPC %s which does not exist', filename, insee_codes[0])
+        current_app.logger.warning('File %s references ZUPC %s which does not exist', filename, insee_codes[0])
         return None
 
     if len(insee_codes) == 1:

--- a/APITaxi2/tasks/stats.py
+++ b/APITaxi2/tasks/stats.py
@@ -126,7 +126,7 @@ def store_active_taxis(last_update):
 
         res = query.one_or_none()
         if not res:
-            current_app.logger.error(
+            current_app.logger.warning(
                 'Taxi %s with operator %s exists in redis but not in postgresql. Skip it.',
                 update.taxi_id, update.operator
             )

--- a/APITaxi2/tests/test_tasks.py
+++ b/APITaxi2/tests/test_tasks.py
@@ -85,19 +85,19 @@ class TestHandleHailTimeout:
         hail = HailFactory(status='received_by_operator')
         VehicleDescriptionFactory(vehicle=hail.taxi.vehicle)
 
-        with mock.patch.object(tasks.operators.current_app.logger, 'error') as mocked_logger:
+        with mock.patch.object(tasks.operators.current_app.logger, 'warning') as mocked_logger:
             tasks.handle_hail_timeout(hail.id, hail.operateur.id, 'sent_to_operator', 'failure')
             assert mocked_logger.call_count == 0
 
     def test_hail_not_found(self, app):
-        with mock.patch.object(tasks.operators.current_app.logger, 'error') as mocked_logger:
+        with mock.patch.object(tasks.operators.current_app.logger, 'warning') as mocked_logger:
             tasks.handle_hail_timeout('1234', '5678', 'received', 'failure')
             assert mocked_logger.call_count == 1
 
 
 class TestSendRequestOperator:
     def test_hail_not_found(self, app):
-        with mock.patch.object(tasks.operators.current_app.logger, 'error') as mocked_logger:
+        with mock.patch.object(tasks.operators.current_app.logger, 'warning') as mocked_logger:
             ret = tasks.send_request_operator('1234', None, None, None)
             assert mocked_logger.call_count == 1
             assert ret is False
@@ -105,7 +105,7 @@ class TestSendRequestOperator:
     def test_hail_not_received(self, app):
         """Send request for an operator when hail status is different from "received"."""
         hail = HailFactory(status='finished')
-        with mock.patch.object(tasks.operators.current_app.logger, 'error') as mocked_logger:
+        with mock.patch.object(tasks.operators.current_app.logger, 'warning') as mocked_logger:
             ret = tasks.send_request_operator(hail.id, None, None, None)
             assert mocked_logger.call_count == 1
             assert ret is False
@@ -129,7 +129,7 @@ class TestSendRequestOperator:
         hail_id = hail.id
         vehicle_description_id = vehicle_description.id
 
-        with mock.patch.object(tasks.operators.current_app.logger, 'error') as mocked_logger:
+        with mock.patch.object(tasks.operators.current_app.logger, 'warning') as mocked_logger:
             ret = tasks.send_request_operator(hail.id, None, None, None)
             assert mocked_logger.call_count == 1
             assert ret is False
@@ -208,7 +208,7 @@ class TestSendRequestOperator:
         with mock.patch(
             'requests.post', requests_post
         ), mock.patch(
-            'flask.current_app.logger.error'
+            'flask.current_app.logger.warning'
         ) as mocked_logger:
             ret = tasks.send_request_operator(hail.id, 'http://whatever', None, None)
             assert ret is False
@@ -242,7 +242,7 @@ class TestSendRequestOperator:
         with mock.patch(
             'requests.post', requests_post
         ), mock.patch(
-            'flask.current_app.logger.error'
+            'flask.current_app.logger.warning'
         ) as mocked_logger:
             ret = tasks.send_request_operator(hail.id, 'http://whatever', None, None)
             assert ret is False
@@ -276,7 +276,7 @@ class TestSendRequestOperator:
         with mock.patch(
             'requests.post', requests_post
         ), mock.patch(
-            'flask.current_app.logger.error'
+            'flask.current_app.logger.warning'
         ) as mocked_logger:
             ret = tasks.send_request_operator(hail.id, 'http://whatever', None, None)
             assert ret is False


### PR DESCRIPTION
Sentry receives all app.logger.error() messages. All these messages are
not fatal errors, but should rather be considered as warnings.