### PR TITLE
clean_db: fix grouping by operator

### DIFF
--- a/APITaxi2/commands/clean_db.py
+++ b/APITaxi2/commands/clean_db.py
@@ -54,11 +54,13 @@ def check_orphans(Model, query, remove=False):
 
     # Only for models with an added_by column
     if issubclass(Model, mixins.HistoryMixin):
+        subquery = query.subquery()
         report = (
-            query.with_entities(func.count(Model.id), User.email)
-            .join(Model.added_by)
+            db.session.query(func.count(), User.email)
+            .select_from(subquery)
+            .join(User, User.id == subquery.c.added_by)
             .group_by(User.email)
-            .order_by(func.count(Model.id).desc())
+            .order_by(func.count().desc())
         )
         print()
         print("\n".join(f'{count:5} | {email}' for count, email in report))


### PR DESCRIPTION
The previous version was already fragile and eventually broke with the
latest SQLAlchemy version.

Use the isolation of a subquery. The order_by wasn't necessary in the
first place.

Example of query:

  SELECT count(*) AS count_1, "user".email AS user_email
  FROM (
    SELECT driver.added_by AS added_by, driver.added_at AS added_at,
      driver.added_via AS added_via, driver.source AS source,
      driver.last_update_at AS last_update_at, driver.id AS id,
      driver.departement_id AS departement_id, driver.birth_date AS
      birth_date, driver.first_name AS first_name, driver.last_name AS
      last_name, driver.professional_licence AS professional_licence
    FROM driver
    LEFT OUTER JOIN taxi ON driver.id = taxi.driver_id
    WHERE taxi.id IS NULL
  ) AS query
  JOIN "user" ON "user".id = query.added_by
  GROUP BY "user".email