### PR TITLE
stats: merging archive hails and the need for hail stats

### DIFF
--- a/APITaxi2/commands/clean_db.py
+++ b/APITaxi2/commands/clean_db.py
@@ -139,10 +139,23 @@ def blur_hails():
     print(f"{count} hails blurred")
 
 
-@clean.command(help='Archive hails after a year')
-def archive_hails():
-    count = clean_db.archive_hails()
-    print(f"{count} hails archived")
+@clean.command(help='Compute stats for hails')
+def compute_stats_hails():
+    count = clean_db.compute_stats_hails()
+    print(f"{count} hails added to stats")
+
+
+# TODO remove after transition
+@clean.command(help='Compute stats for archived hails')
+def compute_archived_hails():
+    count = clean_db.compute_archived_hails()
+    print(f"{count} archived hails added to stats")
+
+
+@clean.command(help='Delete hails after a year')
+def delete_old_hails():
+    count = clean_db.delete_old_hails()
+    print(f"{count} hails deleted")
 
 
 @clean.command(help='Delete taxis after a year of inactivity')

--- a/APITaxi2/tasks/__init__.py
+++ b/APITaxi2/tasks/__init__.py
@@ -21,10 +21,16 @@ def task_blur_hails():
     print(f"{count} hails blurred")
 
 
-@celery.task(name='archive_hails')
-def task_archive_hails():
-    count = clean_db.archive_hails()
-    print(f"{count} hails archived")
+@celery.task(name='compute_stats_hails')
+def task_compute_stats_hails():
+    count = clean_db.compute_stats_hails()
+    print(f"{count} hails added to stats")
+
+
+@celery.task(name='delete_old_hails')
+def task_delete_old_hails():
+    count = clean_db.delete_old_hails()
+    print(f"{count} hails deleted")
 
 
 @celery.task(name='delete_old_taxis')
@@ -46,6 +52,7 @@ def task_delete_old_orphans():
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(crontab(hour=4, minute=0), task_blur_geotaxi.s())
     sender.add_periodic_task(crontab(hour=4, minute=2), task_blur_hails.s())
-    sender.add_periodic_task(crontab(hour=4, minute=4), task_archive_hails.s())
+    sender.add_periodic_task(crontab(hour=4, minute=4), task_delete_old_hails.s())
     sender.add_periodic_task(crontab(hour=4, minute=6), task_delete_old_taxis.s())
     sender.add_periodic_task(crontab(hour=4, minute=8), task_delete_old_orphans.s())
+    sender.add_periodic_task(crontab(hour=4, minute=10), task_compute_stats_hails.s())

--- a/APITaxi_models2/migrations/versions/20221019_14:59:40_a42260766408_stats_hails.py
+++ b/APITaxi_models2/migrations/versions/20221019_14:59:40_a42260766408_stats_hails.py
@@ -1,0 +1,58 @@
+"""stats hails
+
+Revision ID: a42260766408
+Revises: 4069c2c08c49
+Create Date: 2022-10-19 14:59:40.213185
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'a42260766408'
+down_revision = '4d58dd8dee5f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    sources_enum = postgresql.ENUM('form', 'api', name='via', create_type=False)
+
+    op.create_table('stats_hails',
+        sa.Column('added_at', sa.DateTime(), nullable=False),
+        sa.Column('added_via', sources_enum, nullable=False),
+        sa.Column('source', sa.String(length=255), nullable=False),
+        sa.Column('last_update_at', sa.DateTime(), nullable=True),
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('moteur', sa.String(), nullable=False),
+        sa.Column('operateur', sa.String(), nullable=False),
+        sa.Column('incident_customer_reason', sa.String(), nullable=True),
+        sa.Column('incident_taxi_reason', sa.String(), nullable=True),
+        sa.Column('session_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('insee', sa.String(), nullable=True),
+        sa.Column('taxi_hash', sa.String(), nullable=True),
+        sa.Column('reporting_customer', sa.Boolean(), nullable=True),
+        sa.Column('reporting_customer_reason', sa.String(), nullable=True),
+        sa.Column('received', sa.DateTime(), nullable=True),
+        sa.Column('sent_to_operator', sa.DateTime(), nullable=True),
+        sa.Column('received_by_operator', sa.DateTime(), nullable=True),
+        sa.Column('received_by_taxi', sa.DateTime(), nullable=True),
+        sa.Column('accepted_by_taxi', sa.DateTime(), nullable=True),
+        sa.Column('accepted_by_customer', sa.DateTime(), nullable=True),
+        sa.Column('declined_by_taxi', sa.DateTime(), nullable=True),
+        sa.Column('declined_by_customer', sa.DateTime(), nullable=True),
+        sa.Column('timeout_taxi', sa.DateTime(), nullable=True),
+        sa.Column('timeout_customer', sa.DateTime(), nullable=True),
+        sa.Column('incident_taxi', sa.DateTime(), nullable=True),
+        sa.Column('incident_customer', sa.DateTime(), nullable=True),
+        sa.Column('customer_on_board', sa.DateTime(), nullable=True),
+        sa.Column('finished', sa.DateTime(), nullable=True),
+        sa.Column('failure', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id', 'added_at', name='stats_hails_pkey')
+    )
+    op.execute("SELECT create_hypertable('stats_hails', 'added_at')")
+
+def downgrade():
+    op.drop_table('stats_hails')

--- a/APITaxi_models2/unittest/conftest.py
+++ b/APITaxi_models2/unittest/conftest.py
@@ -41,6 +41,8 @@ def _run_postgresql_migrations(psql):
     with psycopg2.connect(**psql.dsn()) as conn:
         with conn.cursor() as cursor:
             cursor.execute('CREATE EXTENSION IF NOT EXISTS postgis')
+            cursor.execute('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+            cursor.execute('CREATE EXTENSION IF NOT EXISTS timescaledb')
         conn.commit()
 
     migrations_dir = pkg_resources.resource_filename(


### PR DESCRIPTION
ArchivedHail was a first attempt at collecting stats but for old hails. When building stats for recent hails using timescaledb, I just happened to reinvent ArchivedHail with a saner base.

Now we have a single source for querying stats, and hails can be deleted at any time after their stats were collected.

This required the dev environment to use timescaledb-ha as a base image (and thus moving to Ubuntu 22.04).